### PR TITLE
Allow the 'proxy' network to be used outside the project root

### DIFF
--- a/config/static.yml
+++ b/config/static.yml
@@ -7,7 +7,6 @@ api:
 
 providers:
   docker:
-    network: proxy
     endpoint: "unix:///var/run/docker.sock"
     watch: true
     exposedByDefault: false

--- a/config/static.yml
+++ b/config/static.yml
@@ -7,6 +7,7 @@ api:
 
 providers:
   docker:
+    network: proxy
     endpoint: "unix:///var/run/docker.sock"
     watch: true
     exposedByDefault: false

--- a/whoami.yml
+++ b/whoami.yml
@@ -10,6 +10,8 @@ services:
       # Enable this container to be mapped by traefik
       # For more information, see: https://docs.traefik.io/providers/docker/#exposedbydefault
       - "traefik.enable=true"
+      # Define the network that should be used
+      - "traefik.docker.network=proxy"
       # URL to reach this container
       - "traefik.http.routers.whoami.rule=Host(`whoami.docker.localhost`)"
       # Activation of TLS


### PR DESCRIPTION
When attempting to use Traefik with other projects (outside of `traefik-v2-https-ssl-localhost/` directory), they didn't work without this change.

I'm assuming that the `whoami.yml` example works without this entry only because it is located in the same directory. I'm not sure about this though.